### PR TITLE
Add 404 page

### DIFF
--- a/src/components/Page.vue
+++ b/src/components/Page.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="page">
-    <PageHeader :title="title" :ghost="false" :sub-title="subtitle">
+    <PageHeader title="Cloud Lada" :ghost="false" :sub-title="`v${version}`">
       <template #extra>
         <slot name="side" />
       </template>
@@ -14,17 +14,16 @@
 <script lang="ts">
 import { Options, Vue } from "vue-class-component";
 import { PageHeader } from "ant-design-vue";
+import { version } from "../../package.json";
 
 @Options({
   components: {
     PageHeader,
   },
-  props: {
-    title: { type: String, required: true },
-    subtitle: { type: String },
-  },
 })
-export default class Page extends Vue {}
+export default class Page extends Vue {
+  version: string = version;
+}
 </script>
 
 <style lang="css" scoped>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,11 +1,17 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
-import Home from "../views/Home.vue";
+import Home from "@/views/Home.vue";
+import NotFound from "@/views/NotFound.vue";
 
 const routes: Array<RouteRecordRaw> = [
   {
     path: "/",
     name: "home",
     component: Home,
+  },
+  {
+    path: "/:pathMatch(.*)*",
+    name: "not-found",
+    component: NotFound,
   },
 ];
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <Page title="Cloud Lada" :subtitle="`v${version}`">
+  <Page>
     <template #side>
       <DonateButton />
       <SourceCodeButton />
@@ -25,7 +25,6 @@
 import Page from "@/components/Page.vue";
 import { Options, Vue } from "vue-class-component";
 import { Card, BadgeRibbon } from "ant-design-vue";
-import { version } from "../../package.json";
 import SourceCodeButton from "@/components/SourceCodeButton.vue";
 import DonateButton from "@/components/DonateButton.vue";
 import LiveStatistics from "@/components/LiveStatistics.vue";
@@ -44,9 +43,7 @@ import Status from "@/components/Status.vue";
     BadgeRibbon,
   },
 })
-export default class Home extends Vue {
-  version: string = version;
-}
+export default class Home extends Vue {}
 </script>
 
 <style lang="css" scoped>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,30 @@
+<template>
+  <Page>
+    <template #content>
+      <Result
+        status="404"
+        title="404"
+        sub-title="Sorry, the page you visited does not exist."
+      >
+        <template #extra>
+          <Button type="primary" href="/">Back Home</Button>
+        </template>
+      </Result>
+    </template>
+  </Page>
+</template>
+
+<script lang="ts">
+import { Options, Vue } from "vue-class-component";
+import { Result, Button } from "ant-design-vue";
+import Page from "@/components/Page.vue";
+
+@Options({
+  components: {
+    Page,
+    Result,
+    Button,
+  },
+})
+export default class NotFound extends Vue {}
+</script>


### PR DESCRIPTION
This commit adds a 404 page when visiting a URL that does not resolve
to a VueJS component. The Page component has been updated so that
the title and subtitle are now static. We're only ever going to have
this title/version combo so we don't need it to be done in each view.

Signed-off-by: David Bond <davidsbond93@gmail.com>